### PR TITLE
Update restler.js

### DIFF
--- a/lib/restler.js
+++ b/lib/restler.js
@@ -143,6 +143,7 @@ mixin(Request.prototype, {
       });
 
       response.on('end', function() {
+        self._fireCancelTimeout();
         response.rawEncoded = body;
         self._decode(new Buffer(body, 'binary'), response, function(err, body) {
           if (err) {
@@ -234,7 +235,7 @@ mixin(Request.prototype, {
       },timeoutMs);
     }
     this.request.on('response', function(response) {
-      self._fireCancelTimeout();
+      //self._fireCancelTimeout();
       self.emit('response', response);
       self._responseHandler(response);
     }).on('error', function(err) {


### PR DESCRIPTION
I found the request cannot be ended when I was in use to get the data. So  I move this code["self._fireCancelTimeout()"]  from "response event" to "end event".

This can solve the problem of request can't end
